### PR TITLE
Mpriston liquibase

### DIFF
--- a/docs/liquibase.md
+++ b/docs/liquibase.md
@@ -1,0 +1,68 @@
+# Liquibase Migrations
+Using Liquibase migrations allows you to make changes to your database tables without having to restart the entire database.
+
+Liquibase allows you to describe changes to the database schema and it uses those descriptions to apply changes to it.
+
+The changes can be described in JSON and are stored in `src/resources/db/migration/changelog/changes`.
+
+Each file is a description of the database changes to each of the defined entities. For all possible changes you can do to the database you can check: https://docs.liquibase.com/change-types/home.html
+
+The key here is consistance, always create the database changelog file after you create a new entity or modify it.
+
+## Commands
+
+### Check changes to database
+```
+mvn liquibase:updateSQL
+```
+This command will show the changes that will be applied when following the change log you described. This will not apply the changes just provide you with a way to inspect it
+
+### Apply chnages to database
+```
+mvn liquibase:update
+```
+This command will apply the changes to the database. The changes will also be applied when you start your application so you wont need to update it before starting the app.
+
+### Sync database to changelog
+```
+mvn liquibase:changelogSync
+```
+This command will make all the changes you currently have be marked as applied already, this is useful when working on a database that already exists, when you don't want for example to create a table that already exists.
+
+### Tagging a version of the database
+```
+mvn liquibase:tag --tag=myTag
+```
+This can be used to mark a version of the database that can be used when doing rollbacks
+
+### Rollback to tag
+```
+mvn liquibase:rollback --tag=myTag
+```
+This command can be used to rollback the database to a previousily marked tag
+
+## Preconditions
+```
+"changeSet": {
+    "preConditions": [
+      {
+        "onFail": "MARK_RAN"
+      },
+      {
+        "not": [
+          {
+            "tableExists": {
+              "tableName": "MY_NEW_TABLE"
+            }
+          }
+        ]
+      }
+    ]
+    "changes": etc
+    }
+``` 
+Preconditions can be set in each of the changes that will help you determine if certain change should be ran or what to do if it fails.
+
+The example above tells liquibase to mark a change as ran in case it fails because the table already exists, very useful when working with an already existing database.
+
+For more information on preconditions you can see https://docs.liquibase.com/concepts/changelogs/preconditions.html

--- a/docs/liquibase.md
+++ b/docs/liquibase.md
@@ -7,7 +7,7 @@ The changes can be described in JSON and are stored in `src/resources/db/migrati
 
 Each file is a description of the database changes to each of the defined entities. For all possible changes you can do to the database you can check: https://docs.liquibase.com/change-types/home.html
 
-The key here is consistance, always create the database changelog file after you create a new entity or modify it.
+The key here is consistency; always create/update the corresponding database changelog file after you create a new entity or modify it.
 
 ## Commands
 
@@ -40,6 +40,9 @@ This can be used to mark a version of the database that can be used when doing r
 mvn liquibase:rollback --tag=myTag
 ```
 This command can be used to rollback the database to a previousily marked tag
+
+The command `mvn liquibase:checkSumClear` is also a useful command when building out a migration, as the checksum of a migration will change as you update the contents of that migration.
+
 
 ## Preconditions
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <version>1.10.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-maven-plugin</artifactId>
+            <version>3.8.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -245,6 +251,15 @@
                             org.springframework.security.core.context.SecurityContextHolder</avoidCallsTo>
                     </avoidCallsTo>
                     <timestampedReports>false</timestampedReports>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.liquibase</groupId>
+                <artifactId>liquibase-maven-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <propertyFile>liquibase.properties</propertyFile>
                 </configuration>
             </plugin>
 

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -11,3 +11,7 @@ app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/pr
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always
 
+spring.liquibase.url=jdbc:h2:file:./target/db-development
+spring.liquibase.user=sa
+spring.liquibase.password=password
+spring.liquibase.enabled=true

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -3,3 +3,8 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
+
+spring.liquibase.url=${JDBC_DATABASE_URL}
+spring.liquibase.user=${JDBC_DATABASE_USERNAME}
+spring.liquibase.password=${JDBC_DATABASE_PASSWORD}
+spring.liquibase.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ management.endpoints.web.exposure.include=mappings
 # see: https://medium.com/@thecodinganalyst/configure-spring-security-csrf-for-testing-on-swagger-e9e6461ee0c1
 springdoc.swagger-ui.csrf.enabled=true
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none
 app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:phtcon@ucsb.edu}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-organic}}
 
@@ -35,3 +35,4 @@ spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUserna
 
 spring.jackson.time-zone=America/Los_Angeles
 
+spring.liquibase.change-log=db/migration/changelog-master.json

--- a/src/main/resources/db/migration/changelog-master.json
+++ b/src/main/resources/db/migration/changelog-master.json
@@ -1,0 +1,5 @@
+{ "databaseChangeLog": [
+    {
+        "includeAll": {"path": "db/migration/changes/"}
+    }
+]}

--- a/src/main/resources/db/migration/changes/Jobs.json
+++ b/src/main/resources/db/migration/changes/Jobs.json
@@ -26,7 +26,7 @@
                       "autoIncrement": true,
                       "constraints": {
                         "primaryKey": true,
-                        "primaryKeyName": "CONSTRAINT_2"
+                        "primaryKeyName": "PRIMARY_KEY_JOBS"
                       },
                       "name": "ID",
                       "type": "BIGINT"

--- a/src/main/resources/db/migration/changes/Jobs.json
+++ b/src/main/resources/db/migration/changes/Jobs.json
@@ -1,0 +1,74 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "Jobs-1",
+          "author": "matt (generated)",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "JOBS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "CONSTRAINT_2"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "CREATED_AT",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "LOG",
+                      "type": "CLOB"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATUS",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "UPDATED_AT",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "CREATED_BY_ID",
+                      "type": "BIGINT"
+                    }
+                  }]
+                ,
+                "tableName": "JOBS"
+              }
+            }]
+          
+        }
+      }
+    
+  
+]}

--- a/src/main/resources/db/migration/changes/Users.json
+++ b/src/main/resources/db/migration/changes/Users.json
@@ -26,7 +26,7 @@
                       "autoIncrement": true,
                       "constraints": {
                         "primaryKey": true,
-                        "primaryKeyName": "CONSTRAINT_4"
+                        "primaryKeyName": "PRIMARY_KEY_ID"
                       },
                       "name": "ID",
                       "type": "BIGINT"

--- a/src/main/resources/db/migration/changes/Users.json
+++ b/src/main/resources/db/migration/changes/Users.json
@@ -1,0 +1,111 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "Users-1",
+          "author": "matt (generated)",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "USERS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "CONSTRAINT_4"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ADMIN",
+                      "type": "BOOLEAN"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "EMAIL_VERIFIED",
+                      "type": "BOOLEAN"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "FAMILY_NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "FULL_NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "GIVEN_NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "INSTRUCTOR",
+                      "type": "BOOLEAN"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "LAST_ONLINE",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "LOCALE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "PICTURE_URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  }]
+                ,
+                "tableName": "USERS"
+              }
+            }]
+          
+        }
+      }
+]}

--- a/src/main/resources/db/migration/changes/ZZ-LinkingTableChanges.json
+++ b/src/main/resources/db/migration/changes/ZZ-LinkingTableChanges.json
@@ -2,7 +2,7 @@
     "databaseChangeLog": [
         {
             "changeSet": {
-                "id": "Jobs-2",
+                "id": "ZZ-1",
                 "author": "matt (generated)",
                 "changes": [
                     {
@@ -23,7 +23,7 @@
         },
         {
             "changeSet": {
-                "id": "ZZ-1",
+                "id": "ZZ-2",
                 "author": "matt (generated)",
                 "changes": [
                     {

--- a/src/main/resources/db/migration/changes/ZZ-LinkingTableChanges.json
+++ b/src/main/resources/db/migration/changes/ZZ-LinkingTableChanges.json
@@ -1,0 +1,47 @@
+{
+    "databaseChangeLog": [
+        {
+            "changeSet": {
+                "id": "Jobs-2",
+                "author": "matt (generated)",
+                "changes": [
+                    {
+                        "createIndex": {
+                            "columns": [
+                                {
+                                    "column": {
+                                        "name": "CREATED_BY_ID"
+                                    }
+                                }
+                            ],
+                            "indexName": "FKKJPYGUUYD5SHXTABV9V5JPE6X_INDEX_2",
+                            "tableName": "JOBS"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "changeSet": {
+                "id": "ZZ-1",
+                "author": "matt (generated)",
+                "changes": [
+                    {
+                        "addForeignKeyConstraint": {
+                            "baseColumnNames": "CREATED_BY_ID",
+                            "baseTableName": "JOBS",
+                            "constraintName": "FKKJPYGUUYD5SHXTABV9V5JPE6X",
+                            "deferrable": false,
+                            "initiallyDeferred": false,
+                            "onDelete": "RESTRICT",
+                            "onUpdate": "RESTRICT",
+                            "referencedColumnNames": "ID",
+                            "referencedTableName": "USERS",
+                            "validate": true
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/main/resources/liquibase.properties
+++ b/src/main/resources/liquibase.properties
@@ -1,0 +1,4 @@
+url: jdbc:h2:file:./target/db-development
+changeLogFile: db/migration/changelog-master.json
+username: sa
+password: password


### PR DESCRIPTION
This PR is is a replacement for #5 based on a snapshot of https://github.com/MPriston/proj-organic `main` branch as of 10:17am Wed Nov 8th, which was then rebased on main.

I've made a branch in the main repo so that we can consider these changes in the context of the main branch of proj-organic (where we are adding tests and CI/CD workflows.)

# Original Description

This PR implements the starter code for database migration into the Project Organic, it adds the initial schema for the existing tables as well as the necessary changes to the pom file to include liquibase on the project
