### PR TITLE
pc - try setting callback url

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,8 +15,7 @@ spring.jpa.open-in-view=false
 spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID:${env.GITHUB_CLIENT_ID:client_id_unset}}
 spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET:${env.GITHUB_CLIENT_SECRET:client_secret_unset}}
 spring.security.oauth2.client.registration.github.scope=email,profile
-
-security.oauth2.client.registration.github.redirect-uri-template: "{baseUrl}/login/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.github.redirectUri=${GITHUB_REDIRECT_URI:${env.GITHUB_REDIRECT_URI:{baseUrl}/login/oauth2/code/github}}
 
 springdoc.swagger-ui.tryItOutEnabled=true
 management.endpoints.web.exposure.include=mappings

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,6 @@ spring.jpa.open-in-view=false
 spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID:${env.GITHUB_CLIENT_ID:client_id_unset}}
 spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET:${env.GITHUB_CLIENT_SECRET:client_secret_unset}}
 spring.security.oauth2.client.registration.github.scope=email,profile
-spring.security.oauth2.client.registration.github.redirectUri=${GITHUB_REDIRECT_URI:${env.GITHUB_REDIRECT_URI:{baseUrl}/login/oauth2/code/github}}
 
 springdoc.swagger-ui.tryItOutEnabled=true
 management.endpoints.web.exposure.include=mappings


### PR DESCRIPTION
In this draft PR, we try setting the callback uri to see if that fixes the problem with the Github API.

If so, we'll need to update the documentation to specify using Github Apps instead of OAuth Apps for Github.