### PR TITLE
Pc fix title

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Happier Cows</title>
+    <title>Organic</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,8 +15,7 @@ spring.jpa.open-in-view=false
 spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID:${env.GITHUB_CLIENT_ID:client_id_unset}}
 spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET:${env.GITHUB_CLIENT_SECRET:client_secret_unset}}
 spring.security.oauth2.client.registration.github.scope=email,profile
-
-security.oauth2.client.registration.github.redirect-uri-template: "{baseUrl}/login/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.github.redirectUri=${GITHUB_REDIRECT_URI:${env.GITHUB_REDIRECT_URI:{baseUrl}/login/oauth2/code/github}}
 
 springdoc.swagger-ui.tryItOutEnabled=true
 management.endpoints.web.exposure.include=mappings

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,6 @@ spring.jpa.open-in-view=false
 spring.security.oauth2.client.registration.github.client-id=${GITHUB_CLIENT_ID:${env.GITHUB_CLIENT_ID:client_id_unset}}
 spring.security.oauth2.client.registration.github.client-secret=${GITHUB_CLIENT_SECRET:${env.GITHUB_CLIENT_SECRET:client_secret_unset}}
 spring.security.oauth2.client.registration.github.scope=email,profile
-spring.security.oauth2.client.registration.github.redirectUri=${GITHUB_REDIRECT_URI:${env.GITHUB_REDIRECT_URI:{baseUrl}/login/oauth2/code/github}}
 
 springdoc.swagger-ui.tryItOutEnabled=true
 management.endpoints.web.exposure.include=mappings


### PR DESCRIPTION
In this PR, we fix the title of the app.

Before (note text on browser tab):

<img width="785" alt="image" src="https://github.com/ucsb-cs156/proj-organic/assets/1119017/14180f00-1420-4779-b262-bb7aaf65b5fc">

After: 

<img width="815" alt="image" src="https://github.com/ucsb-cs156/proj-organic/assets/1119017/13694777-3df2-4a01-83e4-01a970aa819b">

Note that fixing the favicon (the logo which is HappyCows on one example above, and Courses on the other) will be a different issue.

We also fix one setting in application.properties related to the callback url.  Setting this is unnecessary and may lead to problems with oauth.  Better to take the default.