### PR TITLE
Pc add emails to profile

### DIFF
--- a/frontend/src/fixtures/userEmailFixtures.js
+++ b/frontend/src/fixtures/userEmailFixtures.js
@@ -1,0 +1,23 @@
+const userEmailFixtures = {
+    userWithFourEmails:
+        [
+            {
+                "email": "pconrad@cs.ucsb.edu",
+                "githubId": 1119017
+            },
+            {
+                "email": "pconrad.cis@gmail.com",
+                "githubId": 1119017
+            },
+            {
+                "email": "pconrad@engineering.ucsb.edu",
+                "githubId": 1119017
+            },
+            {
+                "email": "pconrad@engr.ucsb.edu",
+                "githubId": 1119017
+            }
+        ],
+};
+
+export { userEmailFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -57,7 +57,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               {
                 currentUser && currentUser.loggedIn ? (
                   <>
-                    <Navbar.Text className="me-3" as={Link} to="/profile">Welcome</Navbar.Text>
+                    <Navbar.Text className="me-3" as={Link} to="/profile">Welcome, {currentUser.root.user.fullName}</Navbar.Text>
                     <Button onClick={doLogout}>Log Out</Button>
                   </>
                 ) : (

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -57,7 +57,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               {
                 currentUser && currentUser.loggedIn ? (
                   <>
-                    <Navbar.Text className="me-3" as={Link} to="/profile">Welcome, {currentUser.root.user.fullName}</Navbar.Text>
+                    <Navbar.Text className="me-3" as={Link} to="/profile">Welcome, {currentUser.root.user.githubLogin}</Navbar.Text>
                     <Button onClick={doLogout}>Log Out</Button>
                   </>
                 ) : (

--- a/frontend/src/main/components/Users/UserEmailsTable.js
+++ b/frontend/src/main/components/Users/UserEmailsTable.js
@@ -1,0 +1,16 @@
+import React from "react";
+import OurTable from "main/components/OurTable"
+
+const columns = [
+    {
+        Header: 'email',
+        accessor: 'email', // accessor is the "key" in the data
+    },
+];
+
+export default function UserEmailsTable({ emails }) {
+    return <OurTable
+        data={emails}
+        columns={columns}
+        testid={"UserEmailsTable"} />;
+};

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -2,6 +2,8 @@ import React from "react";
 import { useCurrentUser } from "main/utils/currentUser";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import ReactJson from "react-json-view";
+import UsersTable from "main/components/Users/UsersTable"
+import UserEmailsTable from "main/components/Users/UserEmailsTable";
 
 const ProfilePage = () => {
 
@@ -14,9 +16,20 @@ const ProfilePage = () => {
     }
 
     return (
-       <BasicLayout>
-            <ReactJson src={currentUser} / >
-       </BasicLayout>
+        <BasicLayout>
+            <h1 className={"mb-3"}>
+                User Profile for {currentUser.root.user.githubLogin}
+            </h1>
+            <UsersTable users={[currentUser.root.user]} />
+            <h2 className={"mt-3 mb-3"}>
+                Emails
+            </h2>
+            <UserEmailsTable emails={currentUser.root.user.emails} />
+            <h2 className={"mt-3 mb-3"}>
+                Debugging Information
+            </h2>
+            <ReactJson src={currentUser} />
+        </BasicLayout>
     );
 };
 

--- a/frontend/src/stories/components/Users/UserEmailsTable.stories.js
+++ b/frontend/src/stories/components/Users/UserEmailsTable.stories.js
@@ -1,0 +1,25 @@
+
+import React from 'react';
+import { userEmailFixtures } from "fixtures/userEmailFixtures";
+import UserEmailsTable from "main/components/Users/UserEmailsTable";
+
+export default {
+    title: 'components/Users/UserEmailsTable',
+    component: UserEmailsTable
+};
+
+const Template = (args) => {
+    return (
+        <UserEmailsTable {...args} />
+    )
+};
+
+export const fourEmails = Template.bind({});
+fourEmails.args = {
+   emails: userEmailFixtures.userWithFourEmails
+};
+
+
+
+
+

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -21,7 +21,7 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText("Welcome")).toBeInTheDocument();
+        expect(await screen.findByText("Welcome, cgaucho")).toBeInTheDocument();
     });
 
     test("renders correctly for admin user", async () => {
@@ -36,7 +36,7 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText("Welcome")).toBeInTheDocument();
+        expect(await screen.findByText("Welcome, pconrad")).toBeInTheDocument();
         const adminMenu = screen.getByTestId("appnavbar-admin-dropdown");
         expect(adminMenu).toBeInTheDocument();        
     });

--- a/frontend/src/tests/components/Users/UserEmailsTable.test.js
+++ b/frontend/src/tests/components/Users/UserEmailsTable.test.js
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import UserEmailsTable from "main/components/Users/UserEmailsTable";
+import { userEmailFixtures } from "fixtures/userEmailFixtures";
+
+describe("UserEmailsTable tests", () => {
+  
+    test("Has the expected colum headers and content", () => {
+        render(
+          <UserEmailsTable emails={userEmailFixtures.userWithFourEmails}/>
+        );
+    
+        const expectedHeaders = ["email"]
+        const expectedFields = ["email"]
+        const testId = "UserEmailsTable";
+
+        expectedHeaders.forEach( (headerText)=> {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach( (field)=> {
+          const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+          expect(header).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-email`)).toHaveTextContent("pconrad@cs.ucsb.edu");
+       
+      });
+});

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -34,6 +34,24 @@ describe("ProfilePage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+        expect(await screen.findAllByText("User Profile for cgaucho"));
+        const header = screen.getByText("User Profile for cgaucho");
+        expect(header).toHaveClass("mb-3");
+
+        expect(screen.queryByText("Not logged in.")).not.toBeInTheDocument();
+        expect(screen.queryByText("Emails")).toBeInTheDocument();
+
+        const emailsHeader = screen.getByText("Emails");
+        expect(emailsHeader).toHaveClass("mt-3");
+        expect(emailsHeader).toHaveClass("mb-3");
+
+        const debuggingInfoHeader = screen.getByText("Debugging Information");
+        expect(debuggingInfoHeader).toHaveClass("mt-3");
+        expect(debuggingInfoHeader).toHaveClass("mb-3");
+
+        expect(screen.getByTestId("UsersTable-cell-row-0-col-githubLogin")).toBeInTheDocument();
+        expect(screen.getByTestId("UsersTable-cell-row-0-col-githubLogin")).toHaveTextContent("cgaucho");
+
     });
 
     test("renders correctly for admin user from UCSB", async () => {

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -34,12 +34,12 @@ describe("ProfilePage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-        expect(await screen.findAllByText("User Profile for cgaucho"));
+        await screen.findAllByText("User Profile for cgaucho");
         const header = screen.getByText("User Profile for cgaucho");
         expect(header).toHaveClass("mb-3");
 
         expect(screen.queryByText("Not logged in.")).not.toBeInTheDocument();
-        expect(screen.queryByText("Emails")).toBeInTheDocument();
+        expect(screen.getByText("Emails")).toBeInTheDocument();
 
         const emailsHeader = screen.getByText("Emails");
         expect(emailsHeader).toHaveClass("mt-3");

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,15 @@
             <artifactId>spring-security-config</artifactId>
         </dependency>
 
+        <!--
+        https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.15.3</version>
+        </dependency>
+
+
         <!-- https://central.sonatype.com/artifact/org.apache.commons/commons-csv/1.10.0 -->
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -307,6 +316,7 @@
                 <dependency>
                     <groupId>com.h2database</groupId>
                     <artifactId>h2</artifactId>
+                    <version>2.2.224</version>
                     <scope>runtime</scope>
                 </dependency>
             </dependencies>

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
@@ -10,6 +10,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Map;
 
 @Slf4j
@@ -32,4 +36,29 @@ public abstract class ApiController {
     return map;
   }
 
+  private ObjectMapper mapper;
+
+  /**
+   * Special ObjectMapper that ignores Mockito mocks
+   * @return ObjectMapper mapper
+   */
+  public ObjectMapper getMapper() {
+    return mapper;
+  }
+
+  public ApiController() {
+   mapper = mapperThatIgnoresMockitoMocks();
+  }
+
+  public static ObjectMapper mapperThatIgnoresMockitoMocks() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    mapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector() {
+      @Override
+      public boolean hasIgnoreMarker(final AnnotatedMember m) {
+        return super.hasIgnoreMarker(m) || m.getName().contains("Mockito");
+      }
+    });
+    return mapper;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/JobsController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 import edu.ucsb.cs156.organic.entities.jobs.Job;
 import edu.ucsb.cs156.organic.jobs.TestJob;
 import edu.ucsb.cs156.organic.repositories.jobs.JobsRepository;
-import edu.ucsb.cs156.organic.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.organic.services.jobs.JobService;
 
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UserInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UserInfoController.java
@@ -3,28 +3,16 @@ package edu.ucsb.cs156.organic.controllers;
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.entities.UserEmail;
 import edu.ucsb.cs156.organic.models.CurrentUser;
-import edu.ucsb.cs156.organic.repositories.UserEmailRepository;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import io.swagger.v3.oas.annotations.Operation;
 
 import java.time.Instant;
-import java.util.List;
 
-import org.kohsuke.github.GHEmail;
-import org.kohsuke.github.GHMyself;
-import org.kohsuke.github.GHUser;
-import org.kohsuke.github.GitHub;
-import org.kohsuke.github.GitHubBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -54,5 +42,13 @@ public class UserInfoController extends ApiController {
     user.setLastOnline(timeNow);
     userRepository.save(user);
     return ResponseEntity.ok().body(timeNow);
+  }
+
+  @Operation(summary = "Get current users emails")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/emails")
+  public Iterable<UserEmail> getUsersEmails() {
+    User user = super.getCurrentUser().getUser();
+    return user.getEmails();
   }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UserInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UserInfoController.java
@@ -18,6 +18,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 @Slf4j
 @Tag(name = "Current User Information")
 @RequestMapping("/api/currentUser")
@@ -29,8 +35,10 @@ public class UserInfoController extends ApiController {
   @Operation(summary = "Get information about current user")
   @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("")
-  public CurrentUser getCurrentUser() {
-    return super.getCurrentUser();
+  public ResponseEntity<String> getCurrentUserAsJson() throws JsonProcessingException {
+    CurrentUser cu = super.getCurrentUser();
+    String cuAsJson = getMapper().writeValueAsString(cu);
+    return ResponseEntity.ok().body(cuAsJson);
   }
 
   @Operation(summary = "Update user's last online time")
@@ -51,4 +59,5 @@ public class UserInfoController extends ApiController {
     User user = super.getCurrentUser().getUser();
     return user.getEmails();
   }
+
 }

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UsersController.java
@@ -15,7 +15,7 @@ import edu.ucsb.cs156.organic.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 
-@Tag(name="User information (admin only)")
+@Tag(name = "User information (admin only)")
 @RequestMapping("/api/admin/users")
 @RestController
 public class UsersController extends ApiController {

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/UserEmailRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/UserEmailRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserEmailRepository extends CrudRepository<UserEmail, String> {
+    Iterable<UserEmail> findByUserGithubId(Long userGithubId);
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/ControllerTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/ControllerTestCase.java
@@ -13,6 +13,8 @@ import edu.ucsb.cs156.organic.services.GrantedAuthoritiesService;
 import edu.ucsb.cs156.organic.testconfig.TestConfig;
 import org.springframework.test.web.servlet.MvcResult;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
@@ -33,6 +35,6 @@ public abstract class ControllerTestCase {
   
   protected Map<String, Object> responseToJson(MvcResult result) throws UnsupportedEncodingException, JsonProcessingException {
     String responseString = result.getResponse().getContentAsString();
-    return mapper.readValue(responseString, Map.class);
+    return mapper.readValue(responseString, new TypeReference<Map<String,Object>>(){});
   }
 }

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -43,10 +43,9 @@ public class UsersControllerTests extends ControllerTestCase {
 
     User u1 = User.builder().githubId(1).build();
     User u2 = User.builder().githubId(2).build();
-    User u = currentUserService.getCurrentUser().getUser();
 
     ArrayList<User> expectedUsers = new ArrayList<>();
-    expectedUsers.addAll(Arrays.asList(u1, u2, u));
+    expectedUsers.addAll(Arrays.asList(u1, u2));
 
     when(userRepository.findAll()).thenReturn(expectedUsers);
     String expectedJson = mapper.writeValueAsString(expectedUsers);

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/UsersControllerTests.java
@@ -8,6 +8,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
 import edu.ucsb.cs156.organic.entities.User;
+import edu.ucsb.cs156.organic.repositories.UserEmailRepository;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import edu.ucsb.cs156.organic.testconfig.TestConfig;
 
@@ -30,6 +31,9 @@ public class UsersControllerTests extends ControllerTestCase {
 
   @MockBean
   UserRepository userRepository;
+
+  @MockBean
+  UserEmailRepository userEmailRepository;
 
   @WithMockUser(roles = { "ADMIN" })
   @Test

--- a/src/test/java/edu/ucsb/cs156/organic/entities/UserEmailTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/entities/UserEmailTests.java
@@ -19,4 +19,14 @@ public class UserEmailTests {
         UserEmail userEmail = UserEmail.builder().email("cgaucho@ucsb.edu").user(user).build();
         assertEquals(12345, userEmail.getGithubId()); 
     }
+
+    /**
+     * for test coverage purposes
+     */
+    @Test
+    void test_noArgsConstructor() {
+        UserEmail userEmail = new UserEmail();
+        assertEquals(null, userEmail.getEmail());
+        assertEquals(null, userEmail.getUser());
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/organic/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/organic/testconfig/MockCurrentUserServiceImpl.java
@@ -2,7 +2,13 @@ package edu.ucsb.cs156.organic.testconfig;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
 import java.time.Instant;
+import java.util.ArrayList;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -10,7 +16,11 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.organic.entities.User;
+import edu.ucsb.cs156.organic.entities.UserEmail;
 import edu.ucsb.cs156.organic.services.CurrentUserServiceImpl;
+import liquibase.pro.packaged.em;
+
+import static org.mockito.Mockito.when;
 
 @Slf4j
 @Service("currentUser")
@@ -19,6 +29,8 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
   public User getMockUser(SecurityContext securityContext, Authentication authentication) {
     Object principal = authentication.getPrincipal();
 
+    String githubLogin = "cgaucho";
+    int githubId = 12345;
     String email = "user@example.org";
     String pictureUrl = "https://example.org/fake.jpg";
     String fullName = "Fake User";
@@ -40,14 +52,23 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     }
 
     User u = User.builder()
+    .githubLogin(githubLogin)
     .email(email)
     .pictureUrl(pictureUrl)
     .fullName(fullName)
     .emailVerified(emailVerified)
     .admin(admin)
-    .githubId(123456)
+    .githubId(githubId)
     .lastOnline(lastOnline)
     .build();
+
+    User userSpy = spy(u);
+  
+    ArrayList<UserEmail> emails = new ArrayList<UserEmail>();
+    UserEmail userEmail = UserEmail.builder().email("cgaucho@ucsb.edu").user(userSpy).build();
+    emails.add(userEmail);   
+
+    when(userSpy.getEmails()).thenReturn(emails);
     
     log.trace("************** ALERT **********************");
     log.trace("************* MOCK USER********************");
@@ -55,10 +76,10 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     log.trace("securityContext={}",securityContext);
     log.trace("principal={}",principal);
     log.trace("user (spring security) ={}",user);
-    log.trace("u (our custom user entity)={}",u);
+    log.trace("u (our custom user entity)={}",userSpy);
     log.trace("************** END ALERT ******************");
 
-    return u;
+    return userSpy;
   }
 
   public User getUser() {


### PR DESCRIPTION
In this PR, we add more user friendly content to the User Profile page, including basic information about the User and a table of the users emails.

We move the raw json display of the result of getCurrentUser to a section called "debugging info". We might eventually remove this, but it's helpful to keep around for now during the early days of development.

Profile page before:

<img width="914" alt="image" src="https://github.com/ucsb-cs156/proj-organic/assets/1119017/7cf942bb-ef39-4d8e-b672-ba9d5be55f21">


Profile page after:

<img width="840" alt="image" src="https://github.com/ucsb-cs156/proj-organic/assets/1119017/a8e877e5-6532-46a5-82ee-dd5a9ea7ddd9">

