### PR TITLE
Add Student Table, Rename Tables, Add basic endpoints for Courses and Students

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/ApiController.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.organic.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
+import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
 import edu.ucsb.cs156.organic.models.CurrentUser;
 import edu.ucsb.cs156.organic.services.CurrentUserService;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +35,15 @@ public abstract class ApiController {
     );
     log.error("Exception thrown: {}", map);
     return map;
+  }
+
+  @ExceptionHandler({ EntityNotFoundException.class })
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public Object handleGenericException(Throwable e) {
+    return Map.of(
+      "type", e.getClass().getSimpleName(),
+      "message", e.getMessage()
+    );
   }
 
   private ObjectMapper mapper;

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -1,7 +1,7 @@
 package edu.ucsb.cs156.organic.controllers;
 
 import edu.ucsb.cs156.organic.entities.Course;
-import edu.ucsb.cs156.organic.entities.CourseStaff;
+import edu.ucsb.cs156.organic.entities.Staff;
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.repositories.CourseRepository;
 import edu.ucsb.cs156.organic.repositories.CourseStaffRepository;
@@ -93,7 +93,7 @@ public class CoursesController extends ApiController {
         Course savedCourse = courseRepository.save(course);
         User u = getCurrentUser().getUser();
 
-        CourseStaff courseStaff = CourseStaff.builder()
+        Staff courseStaff = Staff.builder()
                 .courseId(savedCourse.getId())
                 .githubId(u.getGithubId())
                 .build();
@@ -107,7 +107,7 @@ public class CoursesController extends ApiController {
     @Operation(summary = "Add a staff member to a course")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/addStaff")
-    public CourseStaff addStaff(
+    public Staff addStaff(
             @Parameter(name = "courseId") @RequestParam Long courseId,
             @Parameter(name = "githubLogin") @RequestParam String githubLogin)
             throws JsonProcessingException {
@@ -118,7 +118,7 @@ public class CoursesController extends ApiController {
         User user = userRepository.findByGithubLogin(githubLogin)
                 .orElseThrow(() -> new EntityNotFoundException(User.class, githubLogin.toString()));
 
-        CourseStaff courseStaff = CourseStaff.builder()
+        Staff courseStaff = Staff.builder()
                 .courseId(course.getId())
                 .githubId(user.getGithubId())
                 .user(user)
@@ -133,7 +133,7 @@ public class CoursesController extends ApiController {
     @Operation(summary = "Get Staff for course")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/getStaff")
-    public Iterable<CourseStaff> getStaff(
+    public Iterable<Staff> getStaff(
             @Parameter(name = "courseId") @RequestParam Long courseId
     )
             throws JsonProcessingException {
@@ -141,7 +141,7 @@ public class CoursesController extends ApiController {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
 
-        Iterable<CourseStaff> courseStaff = courseStaffRepository.findByCourseId(course.getId());
+        Iterable<Staff> courseStaff = courseStaffRepository.findByCourseId(course.getId());
         return courseStaff;
     }
 

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -9,34 +9,24 @@ import edu.ucsb.cs156.organic.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import liquibase.pro.packaged.co;
 import lombok.extern.slf4j.Slf4j;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import org.hibernate.Criteria;
-import org.hibernate.FetchMode;
-import org.hibernate.Hibernate;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
 
-import javax.validation.Valid;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 
 @Tag(name = "Courses")
 @RequestMapping("/api/courses")
@@ -71,15 +61,12 @@ public class CoursesController extends ApiController {
     @PostMapping("/post")
     public Course postCourse(
             @Parameter(name = "name", description ="course name, e.g. CMPSC 156" ) @RequestParam String name,
-            @Parameter(name = "school", description ="school abbreviation e.g. ucsb" ) @RequestParam String school,
+            @Parameter(name = "school", description ="school abbreviation e.g. UCSB" ) @RequestParam String school,
             @Parameter(name = "term", description = "quarter or semester, e.g. F23") @RequestParam String term,
             @Parameter(name = "start", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
             @Parameter(name = "end", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
             @Parameter(name = "githubOrg", description = "for example ucsb-cs156-f23" ) @RequestParam String githubOrg)
             throws JsonProcessingException {
-
-        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-        // See: https://www.baeldung.com/spring-date-parameters
 
         Course course = Course.builder()
                 .name(name)

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -4,7 +4,7 @@ import edu.ucsb.cs156.organic.entities.Course;
 import edu.ucsb.cs156.organic.entities.Staff;
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.repositories.CourseRepository;
-import edu.ucsb.cs156.organic.repositories.CourseStaffRepository;
+import edu.ucsb.cs156.organic.repositories.StaffRepository;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -48,7 +48,7 @@ public class CoursesController extends ApiController {
     CourseRepository courseRepository;
 
     @Autowired
-    CourseStaffRepository courseStaffRepository;
+    StaffRepository courseStaffRepository;
 
     @Autowired
     UserRepository userRepository;

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -54,10 +54,11 @@ public class CoursesController extends ApiController {
     UserRepository userRepository;
 
     @Operation(summary = "List all courses")
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
     @GetMapping("/all")
     public Iterable<Course> allCourses() {
         User u = getCurrentUser().getUser();
+        log.info("u={}", u);
         if (u.isAdmin()) {
             return courseRepository.findAll();
         } else {

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/CoursesController.java
@@ -1,0 +1,147 @@
+package edu.ucsb.cs156.organic.controllers;
+
+import edu.ucsb.cs156.organic.entities.Course;
+import edu.ucsb.cs156.organic.entities.CourseStaff;
+import edu.ucsb.cs156.organic.entities.User;
+import edu.ucsb.cs156.organic.repositories.CourseRepository;
+import edu.ucsb.cs156.organic.repositories.CourseStaffRepository;
+import edu.ucsb.cs156.organic.repositories.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import liquibase.pro.packaged.co;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.hibernate.Criteria;
+import org.hibernate.FetchMode;
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Tag(name = "Courses")
+@RequestMapping("/api/courses")
+@RestController
+@Slf4j
+public class CoursesController extends ApiController {
+
+    @Autowired
+    CourseRepository courseRepository;
+
+    @Autowired
+    CourseStaffRepository courseStaffRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Operation(summary = "List all courses")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Course> allCourses() {
+        User u = getCurrentUser().getUser();
+        if (u.isAdmin()) {
+            return courseRepository.findAll();
+        } else {
+            return courseRepository.findCoursesStaffedByUser(u.getGithubId());
+        }
+    }
+
+    @Operation(summary = "Create a new course")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Course postCourse(
+            @Parameter(name = "name", description ="course name, e.g. CMPSC 156" ) @RequestParam String name,
+            @Parameter(name = "school", description ="school abbreviation e.g. ucsb" ) @RequestParam String school,
+            @Parameter(name = "term", description = "quarter or semester, e.g. F23") @RequestParam String term,
+            @Parameter(name = "start", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-10-01T00:00:00 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @Parameter(name = "end", description = "in iso format, i.e. YYYY-mm-ddTHH:MM:SS; e.g. 2023-12-31T11:59:59 see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @Parameter(name = "githubOrg", description = "for example ucsb-cs156-f23" ) @RequestParam String githubOrg)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        Course course = Course.builder()
+                .name(name)
+                .school(school)
+                .term(term)
+                .start(start)
+                .end(end)
+                .githubOrg(githubOrg)
+                .build();
+
+        Course savedCourse = courseRepository.save(course);
+        User u = getCurrentUser().getUser();
+
+        CourseStaff courseStaff = CourseStaff.builder()
+                .courseId(savedCourse.getId())
+                .githubId(u.getGithubId())
+                .build();
+
+        log.info("courseStaff={}", courseStaff);
+        courseStaffRepository.save(courseStaff);
+
+        return savedCourse;
+    }
+
+    @Operation(summary = "Add a staff member to a course")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/addStaff")
+    public CourseStaff addStaff(
+            @Parameter(name = "courseId") @RequestParam Long courseId,
+            @Parameter(name = "githubLogin") @RequestParam String githubLogin)
+            throws JsonProcessingException {
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
+
+        User user = userRepository.findByGithubLogin(githubLogin)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, githubLogin.toString()));
+
+        CourseStaff courseStaff = CourseStaff.builder()
+                .courseId(course.getId())
+                .githubId(user.getGithubId())
+                .user(user)
+                .build();
+
+        courseStaff = courseStaffRepository.save(courseStaff);
+        log.info("courseStaff={}", courseStaff);
+
+        return courseStaff;
+    }
+
+    @Operation(summary = "Get Staff for course")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/getStaff")
+    public Iterable<CourseStaff> getStaff(
+            @Parameter(name = "courseId") @RequestParam Long courseId
+    )
+            throws JsonProcessingException {
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
+
+        Iterable<CourseStaff> courseStaff = courseStaffRepository.findByCourseId(course.getId());
+        return courseStaff;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
@@ -5,8 +5,8 @@ import edu.ucsb.cs156.organic.entities.Staff;
 import edu.ucsb.cs156.organic.entities.Student;
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.repositories.CourseRepository;
-import edu.ucsb.cs156.organic.repositories.CourseStaffRepository;
-import edu.ucsb.cs156.organic.repositories.CourseStudentRepository;
+import edu.ucsb.cs156.organic.repositories.StaffRepository;
+import edu.ucsb.cs156.organic.repositories.StudentRepository;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -50,10 +50,10 @@ public class StudentsController extends ApiController {
     CourseRepository courseRepository;
 
     @Autowired
-    CourseStaffRepository courseStaffRepository;
+    StaffRepository courseStaffRepository;
 
     @Autowired
-    CourseStudentRepository courseStudentRepository;
+    StudentRepository courseStudentRepository;
 
     @Autowired
     UserRepository userRepository;

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/StudentsController.java
@@ -1,0 +1,78 @@
+package edu.ucsb.cs156.organic.controllers;
+
+import edu.ucsb.cs156.organic.entities.Course;
+import edu.ucsb.cs156.organic.entities.Staff;
+import edu.ucsb.cs156.organic.entities.Student;
+import edu.ucsb.cs156.organic.entities.User;
+import edu.ucsb.cs156.organic.repositories.CourseRepository;
+import edu.ucsb.cs156.organic.repositories.CourseStaffRepository;
+import edu.ucsb.cs156.organic.repositories.CourseStudentRepository;
+import edu.ucsb.cs156.organic.repositories.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import liquibase.pro.packaged.co;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.hibernate.Criteria;
+import org.hibernate.FetchMode;
+import org.hibernate.Hibernate;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.organic.errors.EntityNotFoundException;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Tag(name = "Courses")
+@RequestMapping("/api/students")
+@RestController
+@Slf4j
+public class StudentsController extends ApiController {
+
+    @Autowired
+    CourseRepository courseRepository;
+
+    @Autowired
+    CourseStaffRepository courseStaffRepository;
+
+    @Autowired
+    CourseStudentRepository courseStudentRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Operation(summary = "Get Students for course")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<Student> getStaff(
+            @Parameter(name = "courseId") @RequestParam Long courseId
+    )
+            throws JsonProcessingException {
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new EntityNotFoundException(Course.class, courseId.toString()));
+
+        Iterable<Student> students = courseStudentRepository.findByCourseId(course.getId());
+        return students;
+    }
+
+   
+
+}

--- a/src/main/java/edu/ucsb/cs156/organic/controllers/UserInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/UserInfoController.java
@@ -1,8 +1,10 @@
 package edu.ucsb.cs156.organic.controllers;
 
+import edu.ucsb.cs156.organic.entities.Course;
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.entities.UserEmail;
 import edu.ucsb.cs156.organic.models.CurrentUser;
+import edu.ucsb.cs156.organic.repositories.CourseRepository;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
@@ -58,6 +60,14 @@ public class UserInfoController extends ApiController {
   public Iterable<UserEmail> getUsersEmails() {
     User user = super.getCurrentUser().getUser();
     return user.getEmails();
+  }
+
+  @Operation(summary = "Get courses for which current user is on the staff")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/staffedCourses")
+  public Iterable<Course> getStaffedCourses() {
+    User user = super.getCurrentUser().getUser();
+    return userRepository.findCoursesStaffedByUser(user.getGithubId());  
   }
 
 }

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Staff.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Staff.java
@@ -4,14 +4,12 @@ import lombok.*;
 
 import javax.persistence.*;
 
-import java.time.LocalDateTime;
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@Entity(name = "course_staff")
-public class CourseStaff {
+@Entity(name = "staff")
+public class Staff {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Student.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Student.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@Entity(name = "course_student")
+@Entity(name = "entstudent")
 public class Student {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Student.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Student.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@Entity(name = "entstudent")
+@Entity(name = "student")
 public class Student {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/organic/entities/Student.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/Student.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.organic.entities;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "course_student")
+public class Student {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private Long courseId;
+  private String fname;
+  private String lname;
+  private String studentId;
+  private String email;
+  
+  private Integer githubId;
+
+  @OneToOne
+  @JoinColumn(name = "githubId", referencedColumnName = "githubId", insertable = false, updatable = false)
+  private User user;
+}

--- a/src/main/java/edu/ucsb/cs156/organic/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/User.java
@@ -7,6 +7,8 @@ import javax.persistence.*;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
+import liquibase.pro.packaged.t;
+
 import java.time.Instant;
 import java.util.List;
 
@@ -36,6 +38,6 @@ public class User {
 
   @Override
   public String toString() {
-    return String.format("User: githubId=%d githubLogin=%s", githubId, githubLogin);
+    return String.format("User: githubId=%d githubLogin=%s admin=%s", githubId, githubLogin, this.admin);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/organic/entities/User.java
@@ -7,8 +7,6 @@ import javax.persistence.*;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
-import liquibase.pro.packaged.t;
-
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/edu/ucsb/cs156/organic/errors/EntityNotFoundException.java
+++ b/src/main/java/edu/ucsb/cs156/organic/errors/EntityNotFoundException.java
@@ -1,0 +1,8 @@
+package edu.ucsb.cs156.organic.errors;
+
+public class EntityNotFoundException extends RuntimeException {
+  public EntityNotFoundException(Class<?> entityType, Object id) {
+    super("%s with id %s not found"
+        .formatted(entityType.getSimpleName(), id.toString()));
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/CourseRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/CourseRepository.java
@@ -12,6 +12,6 @@ public interface CourseRepository extends CrudRepository<Course, Integer> {
 
    public Optional<Course> findById(Long id);
 
-   @Query("select c from courses c where c.id in (select cs.courseId from course_staff cs where cs.githubId = :githubId)")
+   @Query("select c from courses c where c.id in (select cs.courseId from staff cs where cs.githubId = :githubId)")
    public Iterable<Course> findCoursesStaffedByUser(Integer githubId);
 }

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/CourseRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/CourseRepository.java
@@ -1,20 +1,11 @@
 package edu.ucsb.cs156.organic.repositories;
 
 import edu.ucsb.cs156.organic.entities.Course;
-import liquibase.pro.packaged.Q;
-
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
-
-
-//  private String school;
-//   private String term;
-//   private LocalDateTime start;
-//   private LocalDateTime end;
-//   private String githubOrg;
 
 @Repository
 public interface CourseRepository extends CrudRepository<Course, Integer> {

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/CourseRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/CourseRepository.java
@@ -1,11 +1,26 @@
 package edu.ucsb.cs156.organic.repositories;
 
 import edu.ucsb.cs156.organic.entities.Course;
+import liquibase.pro.packaged.Q;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 
+//  private String school;
+//   private String term;
+//   private LocalDateTime start;
+//   private LocalDateTime end;
+//   private String githubOrg;
+
 @Repository
 public interface CourseRepository extends CrudRepository<Course, Integer> {
 
+   public Optional<Course> findById(Long id);
+
+   @Query("select c from courses c where c.id in (select cs.courseId from course_staff cs where cs.githubId = :githubId)")
+   public Iterable<Course> findCoursesStaffedByUser(Integer githubId);
 }

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/CourseStaffRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/CourseStaffRepository.java
@@ -1,11 +1,15 @@
 package edu.ucsb.cs156.organic.repositories;
 
 import edu.ucsb.cs156.organic.entities.CourseStaff;
+
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-
 @Repository
 public interface CourseStaffRepository extends CrudRepository<CourseStaff, Integer> {
-
+    Iterable<CourseStaff> findByCourseId(Long courseId);
+    Iterable<CourseStaff> findByGithubId(Integer githubId);
+    Optional<CourseStaff> findById(Long id);
 }

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/CourseStaffRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/CourseStaffRepository.java
@@ -1,6 +1,6 @@
 package edu.ucsb.cs156.organic.repositories;
 
-import edu.ucsb.cs156.organic.entities.CourseStaff;
+import edu.ucsb.cs156.organic.entities.Staff;
 
 import java.util.Optional;
 
@@ -8,8 +8,8 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CourseStaffRepository extends CrudRepository<CourseStaff, Integer> {
-    Iterable<CourseStaff> findByCourseId(Long courseId);
-    Iterable<CourseStaff> findByGithubId(Integer githubId);
-    Optional<CourseStaff> findById(Long id);
+public interface CourseStaffRepository extends CrudRepository<Staff, Integer> {
+    Iterable<Staff> findByCourseId(Long courseId);
+    Iterable<Staff> findByGithubId(Integer githubId);
+    Optional<Staff> findById(Long id);
 }

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/CourseStudentRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/CourseStudentRepository.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.organic.repositories;
+
+import edu.ucsb.cs156.organic.entities.Staff;
+import edu.ucsb.cs156.organic.entities.Student;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CourseStudentRepository extends CrudRepository<Student, Integer> {
+    Iterable<Student> findByCourseId(Long courseId);
+    Iterable<Student> findByGithubId(Integer githubId);
+    Optional<Student> findById(Long id);
+}

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/StaffRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/StaffRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CourseStaffRepository extends CrudRepository<Staff, Integer> {
+public interface StaffRepository extends CrudRepository<Staff, Integer> {
     Iterable<Staff> findByCourseId(Long courseId);
     Iterable<Staff> findByGithubId(Integer githubId);
     Optional<Staff> findById(Long id);

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/StudentRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/StudentRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CourseStudentRepository extends CrudRepository<Student, Integer> {
+public interface StudentRepository extends CrudRepository<Student, Integer> {
     Iterable<Student> findByCourseId(Long courseId);
     Iterable<Student> findByGithubId(Integer githubId);
     Optional<Student> findById(Long id);

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/UserRepository.java
@@ -14,6 +14,6 @@ public interface UserRepository extends CrudRepository<User, Integer> {
   Optional<User> findByGithubId(Integer githubId);
   Optional<User> findByGithubLogin(String githubLogin);
 
-   @Query("select c from courses c where c.id in (select cs.courseId from course_staff cs where cs.githubId = :githubId)")
+   @Query("select c from courses c where c.id in (select cs.courseId from staff cs where cs.githubId = :githubId)")
    public Iterable<Course> findCoursesStaffedByUser(Integer githubId);
 }

--- a/src/main/java/edu/ucsb/cs156/organic/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/organic/repositories/UserRepository.java
@@ -1,6 +1,9 @@
 package edu.ucsb.cs156.organic.repositories;
 
+import edu.ucsb.cs156.organic.entities.Course;
 import edu.ucsb.cs156.organic.entities.User;
+
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +13,7 @@ import java.util.Optional;
 public interface UserRepository extends CrudRepository<User, Integer> {
   Optional<User> findByGithubId(Integer githubId);
   Optional<User> findByGithubLogin(String githubLogin);
+
+   @Query("select c from courses c where c.id in (select cs.courseId from course_staff cs where cs.githubId = :githubId)")
+   public Iterable<Course> findCoursesStaffedByUser(Integer githubId);
 }

--- a/src/main/java/edu/ucsb/cs156/organic/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/CurrentUserServiceImpl.java
@@ -53,6 +53,13 @@ public class CurrentUserServiceImpl extends CurrentUserService {
         .user(this.getUser())
         .roles(this.getRoles())
         .build();
+    this.getRoles().forEach( (role) -> {
+      log.info("role={}", role);
+      if (role.getAuthority().equals("ROLE_ADMIN")) {
+        cu.getUser().setAdmin(true);
+      }
+    });
+
     log.info("getCurrentUser returns {}", cu);
     return cu;
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ server.port=${PORT:8080}
 # or updated automatically by Spring Boot.
 
 spring.jpa.hibernate.ddl-auto=none    
-# spring.jpa.hibernate.ddl-auto=update 
+#spring.jpa.hibernate.ddl-auto=update 
 
 
 spring.profiles.active=@springProfiles@

--- a/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
+++ b/src/main/resources/db/migration/changes/0005_CreateCourseTable.json
@@ -88,7 +88,7 @@
           "not": [
             {
               "tableExists": {
-                "tableName": "COURSE_STAFF"
+                "tableName": "STAFF"
               }
             }
           ]
@@ -122,7 +122,7 @@
                 }
               }]
             ,
-            "tableName": "COURSE_STAFF"
+            "tableName": "STAFF"
           }
         }]
       

--- a/src/main/resources/db/migration/changes/0006_CreateCourseStudentTable.json
+++ b/src/main/resources/db/migration/changes/0006_CreateCourseStudentTable.json
@@ -1,0 +1,102 @@
+{ "databaseChangeLog": [
+  {
+    "changeSet": {
+      "id": "changeset-0006a",
+      "author": "pconrad",
+      "preConditions": [
+        {
+          "onFail": "MARK_RAN"
+        },
+        {
+          "not": [
+            {
+              "tableExists": {
+                "tableName": "STUDENTS"
+              }
+            }
+          ]
+        }
+      ],
+      "changes": [
+        {
+          "createTable": {
+            "columns": [
+              {
+                "column": {
+                  "autoIncrement": true,
+                  "constraints": {
+                    "primaryKey": true,
+                    "primaryKeyName": "CONSTRAINT_68"
+                  },
+                  "name": "ID",
+                  "type": "BIGINT"
+                }
+              },
+              {
+                "column": {
+                  "name": "COURSE_ID",
+                  "type": "BIGINT"
+                }
+              },
+              {
+                "column": {
+                  "name": "EMAIL",
+                  "type": "VARCHAR(255)"
+                }
+              },
+              {
+                "column": {
+                  "name": "FNAME",
+                  "type": "VARCHAR(255)"
+                }
+              },
+              {
+                "column": {
+                  "name": "GITHUB_ID",
+                  "type": "INT"
+                }
+              },
+              {
+                "column": {
+                  "name": "LNAME",
+                  "type": "VARCHAR(255)"
+                }
+              },
+              {
+                "column": {
+                  "name": "STUDENT_ID",
+                  "type": "VARCHAR(255)"
+                }
+              }]
+            ,
+            "tableName": "STUDENTS"
+          }
+        }]
+      
+    }
+  },
+  
+  {
+    "changeSet": {
+      "id": "changeset-0006b",
+      "author": "pconrad",
+      "changes": [
+        {
+          "addForeignKeyConstraint": {
+            "baseColumnNames": "GITHUB_ID",
+            "baseTableName": "STUDENTS",
+            "constraintName": "STUDENTS_GITHUB_ID_FK",
+            "deferrable": false,
+            "initiallyDeferred": false,
+            "onDelete": "RESTRICT",
+            "onUpdate": "RESTRICT",
+            "referencedColumnNames": "GITHUB_ID",
+            "referencedTableName": "USERS",
+            "validate": true
+          }
+        }]
+      
+    }
+  }
+  
+]}

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -44,7 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import edu.ucsb.cs156.organic.entities.Course;
-import edu.ucsb.cs156.organic.entities.CourseStaff;
+import edu.ucsb.cs156.organic.entities.Staff;
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.entities.jobs.Job;
 import edu.ucsb.cs156.organic.repositories.CourseRepository;
@@ -187,13 +187,13 @@ public class CoursesControllerTests extends ControllerTestCase {
 
                 User user = User.builder().githubId(12345).githubLogin("scottpchow23").build();
 
-                CourseStaff courseStaffBefore = CourseStaff.builder()
+                Staff courseStaffBefore = Staff.builder()
                                 .courseId(course1.getId())
                                 .githubId(user.getGithubId())
                                 .user(user)
                                 .build();
 
-                CourseStaff courseStaffAfter = CourseStaff.builder()
+                Staff courseStaffAfter = Staff.builder()
                                 .id(456L)
                                 .courseId(course1.getId())
                                 .githubId(user.getGithubId())
@@ -269,21 +269,21 @@ public class CoursesControllerTests extends ControllerTestCase {
                 User user1 = User.builder().githubId(12345).githubLogin("scottpchow23").build();
                 User user2 = User.builder().githubId(67890).githubLogin("pconrad").build();
 
-                CourseStaff courseStaff1 = CourseStaff.builder()
+                Staff courseStaff1 = Staff.builder()
                                 .id(111L)
                                 .courseId(course1.getId())
                                 .githubId(user1.getGithubId())
                                 .user(user1)
                                 .build();
 
-                CourseStaff courseStaff2 = CourseStaff.builder()
+                Staff courseStaff2 = Staff.builder()
                                 .id(222L)
                                 .courseId(course2.getId())
                                 .githubId(user2.getGithubId())
                                 .user(user2)
                                 .build();
 
-                ArrayList<CourseStaff> expectedCourseStaff = new ArrayList<>();
+                ArrayList<Staff> expectedCourseStaff = new ArrayList<>();
                 expectedCourseStaff.addAll(Arrays.asList(courseStaff1, courseStaff2));
 
                 when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.of(course1));

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -48,7 +48,7 @@ import edu.ucsb.cs156.organic.entities.Staff;
 import edu.ucsb.cs156.organic.entities.User;
 import edu.ucsb.cs156.organic.entities.jobs.Job;
 import edu.ucsb.cs156.organic.repositories.CourseRepository;
-import edu.ucsb.cs156.organic.repositories.CourseStaffRepository;
+import edu.ucsb.cs156.organic.repositories.StaffRepository;
 import edu.ucsb.cs156.organic.repositories.UserRepository;
 import edu.ucsb.cs156.organic.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.organic.services.jobs.JobService;
@@ -70,7 +70,7 @@ public class CoursesControllerTests extends ControllerTestCase {
         CourseRepository courseRepository;
 
         @MockBean
-        CourseStaffRepository courseStaffRepository;
+        StaffRepository courseStaffRepository;
 
         @Autowired
         ObjectMapper objectMapper;

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/CoursesControllerTests.java
@@ -1,0 +1,327 @@
+package edu.ucsb.cs156.organic.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.awaitility.Awaitility.await;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import edu.ucsb.cs156.organic.entities.Course;
+import edu.ucsb.cs156.organic.entities.CourseStaff;
+import edu.ucsb.cs156.organic.entities.User;
+import edu.ucsb.cs156.organic.entities.jobs.Job;
+import edu.ucsb.cs156.organic.repositories.CourseRepository;
+import edu.ucsb.cs156.organic.repositories.CourseStaffRepository;
+import edu.ucsb.cs156.organic.repositories.UserRepository;
+import edu.ucsb.cs156.organic.repositories.jobs.JobsRepository;
+import edu.ucsb.cs156.organic.services.jobs.JobService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+@Slf4j
+@WebMvcTest(controllers = CoursesController.class)
+@Import(JobService.class)
+@AutoConfigureDataJpa
+public class CoursesControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UserRepository userRepository;
+
+        @MockBean
+        CourseRepository courseRepository;
+
+        @MockBean
+        CourseStaffRepository courseStaffRepository;
+
+        @Autowired
+        ObjectMapper objectMapper;
+
+        Course course1 = Course.builder()
+                        .id(1L)
+                        .name("CS156")
+                        .school("UCSB")
+                        .term("F23")
+                        .start(LocalDateTime.parse("2023-09-01T00:00:00"))
+                        .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                        .githubOrg("ucsb-cs156-f23")
+                        .build();
+
+        Course course2 = Course.builder()
+                        .id(1L)
+                        .name("CS148")
+                        .school("UCSB")
+                        .term("S24")
+                        .start(LocalDateTime.parse("2024-01-01T00:00:00"))
+                        .end(LocalDateTime.parse("2024-03-31T00:00:00"))
+                        .githubOrg("ucsb-cs148-w24")
+                        .build();
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_get_all_courses() throws Exception {
+
+                // arrange
+
+                ArrayList<Course> expectedCourses = new ArrayList<>();
+                expectedCourses.addAll(Arrays.asList(course1, course2));
+
+                when(courseRepository.findAll()).thenReturn(expectedCourses);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/courses/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(courseRepository, atLeastOnce()).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedCourses);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void user_can_get_only_courses_for_which_they_are_staff() throws Exception {
+
+                // arrange
+
+                ArrayList<Course> expectedCourses = new ArrayList<>();
+                expectedCourses.addAll(Arrays.asList(course1, course2));
+
+                when(courseRepository.findCoursesStaffedByUser(any())).thenReturn(expectedCourses);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/courses/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(courseRepository, atLeastOnce()).findCoursesStaffedByUser(any());
+                String expectedJson = mapper.writeValueAsString(expectedCourses);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_course() throws Exception {
+                // arrange
+
+                Course courseBefore = Course.builder()
+                                .name("CS16")
+                                .school("UCSB")
+                                .term("F23")
+                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .githubOrg("ucsb-cs16-f23")
+                                .build();
+
+                Course courseAfter = Course.builder()
+                                .id(222L)
+                                .name("CS16")
+                                .school("UCSB")
+                                .term("F23")
+                                .start(LocalDateTime.parse("2023-09-01T00:00:00"))
+                                .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                                .githubOrg("ucsb-cs16-f23")
+                                .build();
+
+                when(courseRepository.save(eq(courseBefore))).thenReturn(courseAfter);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/courses/post?name=CS16&school=UCSB&term=F23&start=2023-09-01T00:00:00&end=2023-12-31T00:00:00&githubOrg=ucsb-cs16-f23")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(courseRepository, times(1)).save(courseBefore);
+                String expectedJson = mapper.writeValueAsString(courseAfter);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_add_a_staff_member_to_a_course() throws Exception {
+                // arrange
+
+                User user = User.builder().githubId(12345).githubLogin("scottpchow23").build();
+
+                CourseStaff courseStaffBefore = CourseStaff.builder()
+                                .courseId(course1.getId())
+                                .githubId(user.getGithubId())
+                                .user(user)
+                                .build();
+
+                CourseStaff courseStaffAfter = CourseStaff.builder()
+                                .id(456L)
+                                .courseId(course1.getId())
+                                .githubId(user.getGithubId())
+                                .user(user)
+                                .build();
+
+                when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.of(course1));
+                when(userRepository.findByGithubLogin(eq("scottpchow23"))).thenReturn(Optional.of(user));
+                when(courseStaffRepository.save(eq(courseStaffBefore))).thenReturn(courseStaffAfter);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/courses/addStaff?courseId=1&githubLogin=scottpchow23")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(courseStaffRepository, times(1)).save(courseStaffBefore);
+                String expectedJson = mapper.writeValueAsString(courseStaffAfter);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_cannot_add_staff_to_a_non_existing_course() throws Exception {
+                // arrange
+
+                when(courseRepository.findById(eq(42L))).thenReturn(Optional.empty());
+                // act
+
+                MvcResult response = mockMvc.perform(
+                                post("/api/courses/addStaff?courseId=42&githubLogin=scottpchow23")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                Map<String,String> responseMap = mapper.readValue(response.getResponse().getContentAsString(), new TypeReference<Map<String,String>>(){});
+                Map<String,String> expectedMap = Map.of("message", "Course with id 42 not found", "type", "EntityNotFoundException");
+                assertEquals(expectedMap, responseMap);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_cannot_add_non_existing_user_to_staff_of_an_existing_course() throws Exception {
+                // arrange
+
+                when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.of(course1));
+                when(userRepository.findByGithubLogin(eq("sadGaucho"))).thenReturn(Optional.empty());
+               
+                // act
+
+                MvcResult response = mockMvc.perform(
+                                post("/api/courses/addStaff?courseId=1&githubLogin=sadGaucho")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                Map<String,String> responseMap = mapper.readValue(response.getResponse().getContentAsString(), new TypeReference<Map<String,String>>(){});
+                Map<String,String> expectedMap = Map.of("message", "User with id sadGaucho not found", "type", "EntityNotFoundException");
+                assertEquals(expectedMap, responseMap);
+        }
+
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_get_staff_for_a_course() throws Exception {
+                // arrange
+
+                User user1 = User.builder().githubId(12345).githubLogin("scottpchow23").build();
+                User user2 = User.builder().githubId(67890).githubLogin("pconrad").build();
+
+                CourseStaff courseStaff1 = CourseStaff.builder()
+                                .id(111L)
+                                .courseId(course1.getId())
+                                .githubId(user1.getGithubId())
+                                .user(user1)
+                                .build();
+
+                CourseStaff courseStaff2 = CourseStaff.builder()
+                                .id(222L)
+                                .courseId(course2.getId())
+                                .githubId(user2.getGithubId())
+                                .user(user2)
+                                .build();
+
+                ArrayList<CourseStaff> expectedCourseStaff = new ArrayList<>();
+                expectedCourseStaff.addAll(Arrays.asList(courseStaff1, courseStaff2));
+
+                when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.of(course1));
+                when(courseStaffRepository.findByCourseId(eq(course1.getId()))).thenReturn(expectedCourseStaff);
+
+                // act
+
+                MvcResult response = mockMvc.perform(
+                                get("/api/courses/getStaff?courseId=1")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(courseStaffRepository, times(1)).findByCourseId(eq(course1.getId()));
+                String expectedJson = mapper.writeValueAsString(expectedCourseStaff);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_cannot_get_staff_for_a_non_existing_course() throws Exception {
+                // arrange
+
+                when(courseRepository.findById(eq(42L))).thenReturn(Optional.empty());
+                // act
+
+                MvcResult response = mockMvc.perform(
+                                get("/api/courses/getStaff?courseId=42")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                Map<String,String> responseMap = mapper.readValue(response.getResponse().getContentAsString(), new TypeReference<Map<String,String>>(){});
+                Map<String,String> expectedMap = Map.of("message", "Course with id 42 not found", "type", "EntityNotFoundException");
+                assertEquals(expectedMap, responseMap);
+        }
+
+}

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/StudentsControllerTests.java
@@ -1,0 +1,155 @@
+package edu.ucsb.cs156.organic.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.awaitility.Awaitility.await;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import edu.ucsb.cs156.organic.entities.Course;
+import edu.ucsb.cs156.organic.entities.Staff;
+import edu.ucsb.cs156.organic.entities.Student;
+import edu.ucsb.cs156.organic.entities.User;
+import edu.ucsb.cs156.organic.entities.jobs.Job;
+import edu.ucsb.cs156.organic.repositories.CourseRepository;
+import edu.ucsb.cs156.organic.repositories.StaffRepository;
+import edu.ucsb.cs156.organic.repositories.StudentRepository;
+import edu.ucsb.cs156.organic.repositories.UserRepository;
+import edu.ucsb.cs156.organic.repositories.jobs.JobsRepository;
+import edu.ucsb.cs156.organic.services.jobs.JobService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+@Slf4j
+@WebMvcTest(controllers = StudentsController.class)
+@Import(JobService.class)
+@AutoConfigureDataJpa
+public class StudentsControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UserRepository userRepository;
+
+        @MockBean
+        CourseRepository courseRepository;
+
+        @MockBean
+        StudentRepository studentRepository;
+
+        @MockBean
+        StaffRepository staffRepository;
+
+        @Autowired
+        ObjectMapper objectMapper;
+
+        Course course1 = Course.builder()
+                        .id(1L)
+                        .name("CS156")
+                        .school("UCSB")
+                        .term("F23")
+                        .start(LocalDateTime.parse("2023-09-01T00:00:00"))
+                        .end(LocalDateTime.parse("2023-12-31T00:00:00"))
+                        .githubOrg("ucsb-cs156-f23")
+                        .build();
+
+        Course course2 = Course.builder()
+                        .id(1L)
+                        .name("CS148")
+                        .school("UCSB")
+                        .term("S24")
+                        .start(LocalDateTime.parse("2024-01-01T00:00:00"))
+                        .end(LocalDateTime.parse("2024-03-31T00:00:00"))
+                        .githubOrg("ucsb-cs148-w24")
+                        .build();
+
+        Student student1 = Student.builder()
+                        .id(1L)
+                        .courseId(course1.getId())
+                        .githubId(12345)
+                        .build();
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_get_all_students_for_a_course() throws Exception {
+
+                // arrange
+
+                ArrayList<Student> expectedStudents = new ArrayList<>();
+                expectedStudents.add(student1);
+               
+                when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.of(course1));
+                when(studentRepository.findByCourseId(eq(course1.getId()))).thenReturn(expectedStudents);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/students/all?courseId=1"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(courseRepository, atLeastOnce()).findById(eq(course1.getId()));
+                verify(studentRepository, atLeastOnce()).findByCourseId(eq(course1.getId()));
+                String expectedJson = mapper.writeValueAsString(expectedStudents);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_cannot_get_all_students_for_a_non_existing_course() throws Exception {
+
+                // arrange
+
+               
+                when(courseRepository.findById(eq(course1.getId()))).thenReturn(Optional.empty());
+
+                // act 
+                MvcResult response = mockMvc.perform(get("/api/students/all?courseId=1"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(courseRepository, atLeastOnce()).findById(eq(course1.getId()));
+                
+        }
+
+       
+
+}

--- a/src/test/java/edu/ucsb/cs156/organic/entities/UserTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/entities/UserTests.java
@@ -16,6 +16,6 @@ public class UserTests {
     @Test
     void test_toString() {
         User user = User.builder().githubId(12345).githubLogin("cgaucho").build();
-        assertEquals("User: githubId=12345 githubLogin=cgaucho", user.toString()); 
+        assertEquals("User: githubId=12345 githubLogin=cgaucho admin=false", user.toString()); 
     }
 }

--- a/src/test/java/edu/ucsb/cs156/organic/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/organic/testconfig/MockCurrentUserServiceImpl.java
@@ -48,8 +48,8 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
       pictureUrl = "https://example.org/" +  user.getUsername() + ".jpg";
       fullName = "Fake " + user.getUsername();
       emailVerified = true;
-      admin= (user.getUsername().equals("admin"));
-    }
+      admin = false;
+    } 
 
     User u = User.builder()
     .githubLogin(githubLogin)
@@ -69,7 +69,8 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     emails.add(userEmail);   
 
     when(userSpy.getEmails()).thenReturn(emails);
-    
+   
+
     log.trace("************** ALERT **********************");
     log.trace("************* MOCK USER********************");
     log.trace("authentication={}",authentication);


### PR DESCRIPTION
In this PR, we fix some earlier poor naming choices by simplifying:

* CourseStaff -> Staff
* CourseRosterStudent -> Student

We also add the Student table.

We also add controller endpoints for 
* creating a new course
* listing all courses
* getting all students for a course
* finding courses staffed by a user