### PR TITLE
wh - heroku to dokku in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If it doesn't work at first, e.g. you have a blank page on  <http://localhost:80
 If you see the following on localhost, make sure that you also have the frontend code running in a separate window.
 
 ```
-Failed to connect to the frontend server... On Heroku, be sure that PRODUCTION is defined.  On localhost, open a second terminal window, cd into frontend and type: npm install; npm start";
+Failed to connect to the frontend server... On Dokku, be sure that PRODUCTION is defined.  On localhost, open a second terminal window, cd into frontend and type: npm install; npm start";
 ```
 
 # Accessing swagger

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If it doesn't work at first, e.g. you have a blank page on  <http://localhost:80
 If you see the following on localhost, make sure that you also have the frontend code running in a separate window.
 
 ```
-Failed to connect to the frontend server... On Dokku, be sure that PRODUCTION is defined.  On localhost, open a second terminal window, cd into frontend and type: npm install; npm start";
+Failed to connect to the frontend server... On Dokku, be sure that PRODUCTION is defined.  On localhost, open a second terminal window, cd into frontend and type: npm install; npm start;
 ```
 
 # Accessing swagger


### PR DESCRIPTION
# Overview

Hosting service has been switched from heroku to dokku. The README instruction offhandedly mentioned heroku instead.

# Issues Addressed

Changed all mentions of heroku to dokku. This may reduce confusion for students.
