### PR TITLE
Fix Flaky Test

### DIFF
--- a/src/main/java/edu/ucsb/cs156/organic/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/organic/controllers/JobsController.java
@@ -63,7 +63,8 @@ public class JobsController extends ApiController {
     @PostMapping("/launch/testjob")
     public Job launchTestJob(
         @Parameter(name="fail") @RequestParam Boolean fail, 
-        @Parameter(name="sleepMs") @RequestParam Integer sleepMs
+        @Parameter(name="sleepMs") @RequestParam Integer sleepMs,
+        @Parameter(name="id") @RequestParam Integer id
     ) {
         TestJob testJob = TestJob.builder()
         .fail(fail)
@@ -75,6 +76,6 @@ public class JobsController extends ApiController {
             throw new IllegalArgumentException("sleepMs must be between 0 and 60000");
         }
 
-        return jobService.runAsJob(testJob);
+        return jobService.runAsJob(testJob, id);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/organic/services/jobs/JobService.java
+++ b/src/main/java/edu/ucsb/cs156/organic/services/jobs/JobService.java
@@ -20,10 +20,11 @@ public class JobService {
   @Autowired
   private JobService self;
 
-  public Job runAsJob(JobContextConsumer jobFunction) {
+  public Job runAsJob(JobContextConsumer jobFunction, long id) {
     Job job = Job.builder()
       .createdBy(currentUserService.getUser())
       .status("running")
+      .id(id)
       .build();
 
     jobsRepository.save(job);

--- a/src/test/java/edu/ucsb/cs156/organic/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/organic/controllers/JobsControllerTests.java
@@ -159,7 +159,7 @@ public class JobsControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc
-                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=2000").with(csrf()))
+                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=2000&id=1").with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
                 // assert
@@ -209,20 +209,31 @@ public class JobsControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc
-                                .perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=4000").with(csrf()))
+                                .perform(post("/api/jobs/launch/testjob?fail=true&sleepMs=200&id=2").with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
                 String responseString = response.getResponse().getContentAsString();
                 Job jobReturned = objectMapper.readValue(responseString, Job.class);
 
+                log.info("---------------WAITING FOR JOB TO FAIL------------------------");
+
                 assertEquals("running", jobReturned.getStatus());
 
-                await().atMost(5, SECONDS)
+                await().atMost(10, SECONDS)
                 .untilAsserted(() -> {
+                        log.info("---------------TESTING JOB TO FAIL------------------------");
                         verify(jobsRepository, atLeast(1)).save(jobCaptor.capture());                        
                         List<Job> values = jobCaptor.getAllValues();
-                        assertEquals("error", values.get(0).getStatus(), "first saved job should show running");
-                        assertEquals(jobFailed.getLog(), values.get(0).getLog());
+                        log.info("JOB LIST LENGTH: "+values.size());
+                        Job target = Job.builder().id(999).log("Dummy job that will not be used").build();
+                        for(int i=0;i<(int)values.size();i++){
+                                if(values.get(i).getId() == 2){
+                                        target = values.get(i);
+                                        break;
+                                }
+                        }
+                        assertEquals("error", target.getStatus(), "first saved job should show running");
+                        assertEquals(jobFailed.getLog(), target.getLog());
                 });
         }
 
@@ -234,7 +245,7 @@ public class JobsControllerTests extends ControllerTestCase {
                                 "message", "sleepMs must be between 0 and 60000");
                 String expected = mapper.writeValueAsString(expectedMap);       
                 MvcResult response = mockMvc
-                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=-1").with(csrf()))
+                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=-1&id=3").with(csrf()))
                                 .andExpect(status().isBadRequest()).andReturn();
                 assertInstanceOf(IllegalArgumentException.class, response.getResolvedException());
                 assertEquals(expected, response.getResponse().getContentAsString());
@@ -255,7 +266,7 @@ public class JobsControllerTests extends ControllerTestCase {
                                 "message", "sleepMs must be between 0 and 60000");
                 String expected = mapper.writeValueAsString(expectedMap);       
                 MvcResult response = mockMvc
-                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=60001").with(csrf()))
+                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=60001&id=4").with(csrf()))
                                 .andExpect(status().isBadRequest()).andReturn();
                 assertInstanceOf(IllegalArgumentException.class, response.getResolvedException());
                 assertEquals(expected, response.getResponse().getContentAsString());
@@ -266,7 +277,7 @@ public class JobsControllerTests extends ControllerTestCase {
         public void admin_launch_test_job_with_boundary_parameter_0() throws Exception {
                 // boundary are 0 and 60000
                 mockMvc
-                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=0").with(csrf()))
+                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=0&id=5").with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 
         }
@@ -276,7 +287,7 @@ public class JobsControllerTests extends ControllerTestCase {
         public void admin_launch_test_job_with_boundary_parameter_60000() throws Exception {
 
                 mockMvc
-                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=60000").with(csrf()))
+                                .perform(post("/api/jobs/launch/testjob?fail=false&sleepMs=60000&id=6").with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
         }
 


### PR DESCRIPTION
In this PR, we bring in code from:

* <https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/pull/22/>

in which Tianle fixed a flaky test with the jobs system.

Here's his PR description:

---

In this PR, I identified the reason behind the failing CI. Took measures to fix it.

## Cause of the bug

The `jobCaptor` will give a list of all `Job` objects constructed. However, because the tests might run out of order, the first one is not guaranteed to be the one that should fail. What made things worse is that since `jobCaptor` will give a list of `Job`s created previously, it will call the constructor again and again when obtaining the list. Thus, the number of jobs in the list grows exponentially. I didn't address this problem. Instead, I just gave every job an ID, so that we can find the job that should fail when asserting.

## How my approach fixed it

I fixed this bug by adding an `id` field for the `JobService` class and `JobController` class so that after a job has been created, we can always find it by searching its `id`. After this modification, I changed the test case to explicitly search for the job it created by `id` and assert that a specific job should fail to run.

For the whole process of my exploration, please see here: https://github.com/yuxiaolejs/proj-organic-s24-5pm-3/blob/Tianle-Jobs/src/test/java/edu/ucsb/cs156/organic/controllers/JobsControllerTests.java

## More suggestions

To make this job service really usable, I think the best way is just not to call the captor at all, and instead, make a new class that acts like a job queue, make it a bean, and use dependency injection to make a global object of it that's available to every controller. This step will take a significant amount of time but I will implement it while working on the repo creation part.

Fixes the bug mentioned in:
* <https://github.com/ucsb-cs156-s24/proj-organic-s24-5pm-3/issues/21>

